### PR TITLE
fix: properly save wallet custom url

### DIFF
--- a/packages/api/src/intear.ts
+++ b/packages/api/src/intear.ts
@@ -642,7 +642,7 @@ export class WalletAdapter {
               methodNames: functionCallKeyAdded ? (methodNames ?? []) : [],
               logoutKey: logoutKey,
               networkId: networkId,
-              walletUrl: event.origin,
+              walletUrl: event.data.walletUrl,
               useBridge: useBridge,
             };
             window.localStorage.setItem(STORAGE_KEY, JSON.stringify(dataToSave));


### PR DESCRIPTION
When you choose Web Beta, it used to still request send transaction / sign message from wallet.intear.tech instead of staging.wallet.intear.tech